### PR TITLE
Remove portainer lavels for nginx and letsencrypt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     restart: always
     labels:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
-      - io.portainer.accesscontrol.teams: mila
+
   letsencrypt:
     image: jrcs/letsencrypt-nginx-proxy-companion:dev
     container_name: letsencrypt
@@ -88,8 +88,6 @@ services:
       - ./certs:/etc/nginx/certs:rw
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:rw
-    labels:
-      - io.portainer.accesscontrol.teams: mila
 
   # A PostgreSQL database.
   collectivo-db:


### PR DESCRIPTION
For the portainer labels in nginx and letsencrypt, there was an error that the label has to be a string. This PR solves the issue by removing the label for these two services. Another solution could be to change the formatting of the label.